### PR TITLE
Don't use clippy-check action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --features "${{ matrix.features }} -- -D warnings"
+          args: --features "${{ matrix.features }}" -- -D warnings
 
 
   # Test that 3photons runs and produces sensible output on all supported

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,10 @@ jobs:
           args: --features "${{ matrix.features }}"
 
       - name: Check clippy lints
-        uses: actions-rs/clippy-check@v1
+        uses: actions-rs/cargo@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features "${{ matrix.features }}" -- -D warnings
+          command: clippy
+          args: --features "${{ matrix.features }} -- -D warnings"
 
 
   # Test that 3photons runs and produces sensible output on all supported


### PR DESCRIPTION
It doesn't work on external pull requests, and I don't want to duplicate the whole workflow just to get nicer annotations.